### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/server/language-wrappers/rust-wrapper.ts
+++ b/server/language-wrappers/rust-wrapper.ts
@@ -189,7 +189,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 let tasks = vec![
-    ${tasks.map((task, i) => `"${task.replace(/"/g, '\\"')}"`).join(',\n    ')}
+    ${tasks.map((task, i) => `"${task.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`).join(',\n    ')}
 ];
 
 println!("🚀 Executing {} tasks concurrently", tasks.len());


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/CryptoQuestTheShardsOfGenesisMMORPG/security/code-scanning/2](https://github.com/CreoDAMO/CryptoQuestTheShardsOfGenesisMMORPG/security/code-scanning/2)

To fix the issue, we need to ensure that backslashes (`\`) in the `task` strings are properly escaped. This can be achieved by replacing each backslash with a double backslash (`\\`) before escaping double quotes. The best way to do this is to chain `.replace(/\\/g, '\\\\')` before `.replace(/"/g, '\\"')`. This ensures that all backslashes are escaped before handling double quotes.

The change should be made on line 192, where the `task.replace` method is used. No additional imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
