### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "tailwindcss-animate": "^1.0.7",
     "wouter": "^3.7.1",
     "ws": "^8.18.3",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,4 +1,5 @@
 import express, { type Express } from "express";
+import rateLimit from "express-rate-limit";
 import fs from "fs";
 import path from "path";
 import { createServer as createViteServer, createLogger } from "vite";
@@ -41,7 +42,11 @@ export async function setupVite(app: Express, server: Server) {
   });
 
   app.use(vite.middlewares);
-  app.use("*", async (req, res, next) => {
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+  });
+  app.use("*", limiter, async (req, res, next) => {
     const url = req.originalUrl;
 
     try {


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/CryptoQuestTheShardsOfGenesisMMORPG/security/code-scanning/3](https://github.com/CreoDAMO/CryptoQuestTheShardsOfGenesisMMORPG/security/code-scanning/3)

To address the issue, we will add rate limiting to the route handler flagged by CodeQL. The `express-rate-limit` package is a well-known library for implementing rate limiting in Express applications. 

**Steps to fix:**
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Configure a rate limiter with appropriate settings (e.g., maximum requests per time window).
4. Apply the rate limiter middleware to the flagged route handler.

This fix ensures that the route handler is protected against abuse by limiting the number of requests it can handle within a specified time frame.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
